### PR TITLE
added small correction to example of use in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ import { CardStack, Card } from 'react-cardstack';
 	</Card>
 
 	<Card background='#27AE60'>
-		<NumberTwo />
+		<h1>Number 2</h1>
 	</Card>
 
 </CardStack>


### PR DESCRIPTION
Hello,
I copied and pasted the example of use
```js
import { CardStack, Card } from 'react-cardstack';

<CardStack
	height={500}
	width={400}
	background='#f8f8f8'
	hoverOffset={25}>

	<Card background='#2980B9'>
		<h1>Number 1</h1>
	</Card>

	<Card background='#27AE60'>
		<NumberTwo />
	</Card>

</CardStack>
```
 And i had an error because  
```js
<NumberTwo />
```
is not defined, so i replaced it with
```js
<h1>Number 1</h1>
```
and problem solved.