### PR TITLE
React.PropTypes has moved into a different package since React v15.5. Should use the prop-types library instead.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint": "^2.9.0",
     "eslint-config-keystone": "^2.2.0",
     "eslint-plugin-react": "^5.0.1",
+    "prop-types": "^15.5.7", 
     "react-dom": "^15.0.2",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0"

--- a/src/cardstack.jsx
+++ b/src/cardstack.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const equalsZero = (num) => num === 0;
 const errorMessage = 'CardStack component must have at least two child Card components. Please check the children of this CardStack instance.';
@@ -81,10 +82,10 @@ const styles = {
 };
 
 CardStack.propTypes = {
-	background: React.PropTypes.string,
-	height: React.PropTypes.number,
-	hoverOffset: React.PropTypes.number,
-	width: React.PropTypes.number,
+	background: PropTypes.string,
+	height: PropTypes.number,
+	hoverOffset: PropTypes.number,
+	width: PropTypes.number,
 };
 
 CardStack.defaultProps = {


### PR DESCRIPTION
Refer this

https://reactjs.org/docs/typechecking-with-proptypes.html

Updated files accordingly