### PR TITLE
Fix: Changed the CardStack import name in index.js file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import CardStack from './Cardstack';
+import CardStack from './CardStack';
 import Card from './Card';
 
 export { Card, CardStack };


### PR DESCRIPTION
The name of the CardStack file is camel cased but the import in index.js file is not camel-cased.  Fixed the issue. Please let me know if I had to something else to get this merged into master.